### PR TITLE
Fixed missing asset mappings for test sources

### DIFF
--- a/sbt-jscs-plugin-tester/src/test/assets/js/test.js
+++ b/sbt-jscs-plugin-tester/src/test/assets/js/test.js
@@ -1,0 +1,5 @@
+function plus (a, b) {
+  // invalid comment
+  var c = a+b;
+  return c
+}

--- a/src/main/scala/com/hindsightsoftware/sbt/jscs/SbtJscs.scala
+++ b/src/main/scala/com/hindsightsoftware/sbt/jscs/SbtJscs.scala
@@ -26,16 +26,23 @@ object SbtJscs extends AutoPlugin {
   import com.typesafe.sbt.jse.JsEngineImport.JsEngineKeys._
   import com.typesafe.sbt.web.SbtWeb.autoImport._
 
-  val settings = Seq(
-    includeFilter := "*.js" | "*.jsx",
+  val commonSettings = Seq(
+    includeFilter := "*.js" | "*.jsx"
+  )
+
+  val settings = commonSettings ++ Seq(
     sourceDirectory in jscs := (sourceDirectory in Assets).value,
     unmanagedSourceDirectories := Seq(sourceDirectory.value)
+  )
+
+  val testSettings = commonSettings ++ Seq(
+    sourceDirectory in jscs := (sourceDirectory in TestAssets).value
   )
 
   override def projectSettings = inTask(jscs)(
     SbtJsTask.jsTaskSpecificUnscopedSettings ++
       inConfig(Assets)(settings) ++
-      inConfig(TestAssets)(settings) ++
+      inConfig(TestAssets)(testSettings) ++
       Seq(
         moduleName := "jscs",
         shellFile := getClass.getClassLoader.getResource("jscs-shell.js"),


### PR DESCRIPTION
Passing the setting `sourceDirectory in jscs := (sourceDirectory in Assets).value` to both `inConfig(Assets)` and `inConfig(TestAssets)` was causing the following error when js files existed within the test assets directory:

```
> web-assets-test:jscs
[info] Checking JavaScript test code style on 1 source(s)
[trace] Stack trace suppressed: run last web-assets-test:jscs for the full output.
[error] (web-assets-test:jscs) No mapping for /home/mzajac/sbt-jscs/sbt-jscs-plugin-tester/src/test/assets/js/test.js
```

I split the settings into two different sets, which avoids the error. Though, to be honest it also works if if you remove `sourceDirectory in jscs` entirely, for both `jscs` and `web-assets-test:jscs`, so I'm not sure what these settings are meant to accomplish.
